### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ in practice:
 Scriptster::log :info, "Checking branches"
 
 git_cmd = Scriptster::cmd "git branch",
-  :show_out = true,
-  :show_err = true
+  :show_out => true,
+  :show_err => true
 
+branch = "develop"
 branch_exists = git_cmd.out.split("\n").grep(/#{branch}/).length > 0
 Scriptster::log(:warn, "Branch '#{branch}' not found") unless branch_exists
 ```


### PR DESCRIPTION
Hello! Thank you for good Gem :+1: 

I found a little bit of mistake in the README document below.

``` ruby
Scriptster::log :info, "Checking branches"

git_cmd = Scriptster::cmd "git branch",
  :show_out = true,
  :show_err = true

branch_exists = git_cmd.out.split("\n").grep(/#{branch}/).length > 0
Scriptster::log(:warn, "Branch '#{branch}' not found") unless branch_exists
```

I guessed `:show_out = true` is typo of `:show_out => true`, so I corrected these mistakes.
And then, I thought the snippet had better work just by copy and paste, but it didn't because there's not a local variable `branch`. So I added it.
