### PR TITLE
closes stdin in shellcmd to prevent some commands for hanging

### DIFF
--- a/lib/scriptster/shellcmd.rb
+++ b/lib/scriptster/shellcmd.rb
@@ -80,6 +80,7 @@ module Scriptster
     # The function will block until the command has finished.
     def run
       Open3.popen3(@cmd) do |stdin, stdout, stderr, wait_thr|
+        stdin.close # leaving stdin open when we don't use it can cause some commands to hang
         stdout_buffer=""
         stderr_buffer=""
 

--- a/lib/scriptster/version.rb
+++ b/lib/scriptster/version.rb
@@ -1,4 +1,4 @@
 module Scriptster
   # The version of this library
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
I know you haven't update your project lately, but it still works well!  I found a problem when building some scripts that some commands wouldn't exit because they were still waiting for stdin input.  So this simple fix closes it since its not used in the run command.